### PR TITLE
Temp directory used for storage now Windows compatible

### DIFF
--- a/NissanConnect.class.php
+++ b/NissanConnect.class.php
@@ -283,7 +283,7 @@ class NissanConnect {
     private function prepare($skip_local_file = FALSE) {
         if (empty($this->config->vin) || empty($this->config->dcmID) || empty($this->config->customSessionID) || empty($this->config->UserVehicleBoundTime)) {
             $uid = md5($this->config->username);
-            $local_storage_file = "/tmp/.nissan-connect-storage-$uid.json";
+            $local_storage_file = sys_get_temp_dir() . "/.nissan-connect-storage-$uid.json";
             if (file_exists($local_storage_file) && !$skip_local_file) {
                 $json = @json_decode(file_get_contents($local_storage_file));
                 $this->config->vin = @$json->vin;


### PR DESCRIPTION
Thanks for your awesome Nissan Connect code. I run a nightly script on a Windows machine and develop on a Mac. To make your code work on both, I've replaced the /tmp directory used for $local_storage with the cross-platform sys_get_tmp_dir() as there is no /tmp on a standard Windows build by default.