### PR TITLE
Fix for battery status updates, which no longer work as of 2018-12-25

### DIFF
--- a/NissanConnect.class.php
+++ b/NissanConnect.class.php
@@ -135,6 +135,46 @@ class NissanConnect {
         $result = $this->sendRequest('BatteryRemoteChargingRequest.php');
         return $result;
     }
+    /**
+     * Get driving history for the specified date
+     *
+     * @param date $targetDate Specify date to request information for
+     *
+     * @return stdClass
+     * @throws Exception
+     */
+    public function getHistory($targetDate=null) {
+        $this->prepare();
+        $result = $this->sendRequest('CarKarteDetailInfoRequest.php', array('TargetDate' => $targetDate));
+        return $result;
+    }
+
+    /*
+     * Get current location
+     * @return stdClass
+     * @throws Exception
+
+     * POST https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/MyCarFinderRequest.php HTTP/1.1
+     * Eiter wait until success, or keep requesting:
+     * POST https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/MyCarFinderResultRequest.php HTTP/1.1
+     */
+    public function getLocation() {
+      $result = $this->sendRequest('MyCarFinderRequest.php');
+      return $this->waitUntilSuccess('MyCarFinderResultRequest.php');
+    }
+
+    /**
+     * Get the last known location
+     *
+     * @return stdClass
+     * @throws Exception
+     */
+    public function lastLocation() {
+        $this->prepare();
+        $result = $this->sendRequest('MyCarFinderLatLng.php');
+        return $result;
+    }
+
 
     /**
      * Get battery & climate control status.
@@ -279,11 +319,6 @@ class NissanConnect {
         if (array_search($response->{$what}->OperationResult, $allowed_op_result) === FALSE) {
             throw new Exception("Invalid 'OperationResult' received in call to '{$what}Request.php': " . $response->{$what}->OperationResult, static::ERROR_CODE_INVALID_RESPONSE);
         }
-    }
-
-    public function getLocation() {
-      $result = $this->sendRequest('MyCarFinderRequest.php');
-      return $this->waitUntilSuccess('MyCarFinderResultRequest.php');
     }
 
     /**

--- a/NissanConnect.class.php
+++ b/NissanConnect.class.php
@@ -46,7 +46,16 @@ class NissanConnect {
     /* @var boolean Enable to echo debugging information into the PHP error log. */
     public $debug = FALSE;
 
-    private $baseURL = 'https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/';
+    # The API URL is changed occasionally when Nissan introduce a new version.
+
+    # When the API changes, it's worth taking a look at other sources, such as:
+    # https://github.com/filcole/pycarwings2/issues/
+    # https://github.com/jdhorne/pycarwings2/issues/
+
+    private $baseURL = 'https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/';  # No longer works for some, but works in Sweden. Tweaks were needed to make it work after 2018-12-25
+    # private $baseURL = 'https://gdcportalgw.its-mo.com/api_v181217_NE/gdc/';    # New December 2018, but doesn't seem to work, gives {"status":408}
+    # private $baseURL = 'https://gdcportalgw.its-mo.com/api_v180117_NE/gdc/';    # New from Summer 2018? Not working as of Jan 2019, 404
+    # private $baseURL = 'https://gdcportalgw.its-mo.com/gworchest_160803A/gdc/'; # Stopped working summer 2018
 
     private $resultKey = NULL;
     private $config = NULL;
@@ -137,13 +146,11 @@ class NissanConnect {
      */
     public function getStatus($option = 0) {
         $this->prepare();
+
         if ($option != static::STATUS_QUERY_OPTION_CACHED) {
             $this->sendRequest('BatteryStatusCheckRequest.php');
-            if ($option != static::STATUS_QUERY_OPTION_ASYNC) {
-                $expected_last_updated_date = time();
-                $this->debug("Expected last updated date: " . date("Y-m-d H:i:s", $expected_last_updated_date));
-                $this->waitUntilSuccess('BatteryStatusCheckResultRequest.php');
-            }
+            $expected_last_updated_date = time();
+            $this->debug("Expected last updated date: " . date("Y-m-d H:i:s", $expected_last_updated_date));
         }
         if ($option == static::STATUS_QUERY_OPTION_ASYNC) {
             return NULL;


### PR DESCRIPTION
This pull request contains a fix for battery status updates, which no longer work as of 2018-12-25, as well as some notes on the different base URLs that are / have been available.

The problem is that BatteryStatusCheckResultRequest.php just returns  `{"status":200,"responseFlag":"0"}` indefinitely, so it just keeps retrying until it times out. Instead, you now have to compare timestamps to see when the update is done.

I haven't delved into how the async option is used, but with these changes, it'll no longer work as intended. Presumably, the thing to do would be to just remove this bit:

```
if ($option == static::STATUS_QUERY_OPTION_ASYNC) {
    return NULL;
}
```