### PR TITLE
Added lockDoors for Gen2 Models + Typo Fix to avoid errors.

### DIFF
--- a/NissanConnect.class.php
+++ b/NissanConnect.class.php
@@ -46,7 +46,7 @@ class NissanConnect {
     /* @var boolean Enable to echo debugging information into the PHP error log. */
     public $debug = FALSE;
 
-    private $baseURL = 'https://gdcportalgw.its-mo.com/gworchest_160803A/gdc/';
+    private $baseURL = 'https://gdcportalgw.its-mo.com/gworchest_160803EC/gdc/';
 
     private $resultKey = NULL;
     private $config = NULL;

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "This is a simple library that will allow you to use the Nissan Connect (was Carwings) API to check on your Nissan LEAF, and start/stop climate control, or start charging.",
     "keywords": ["api","nissan","LEAF","NissanConnect","carwings"],
     "homepage": "https://github.com/gboudreau/nissan-connect-php",
-    "license": "GPLv3",
+    "license": "GPL-3.0-or-later",
     "authors": [
         {
             "name": "Guillaume Boudreau",


### PR DESCRIPTION
I think the file I use is different, so instead of pasting the whole file, here is the changes I made: Can you please add it to the new-api?

    /**
     * Lock Car Door.
     *
     * @param int $pin Requires a 4 digit security PIN as configured in the Nissan Connect App
     * @param bool $waitForResult Should we wait until the command result is known, before returning? Enabling this will wait until the car executed the command, and returned the response, which can sometimes take a few minutes. @deprecated
     *
     * @return stdClass
     * @throws Exception
     */
    public function lockDoor($pin = 0000, $waitForResult = FALSE) {
        $this->prepare();
        $params["remoteRequest"]["authorizationKey"] = $pin;
        $result = $this->sendRequest("remote/vehicles/{$this->config->vin}/accounts/{$this->config->accountID}/rdl/createRDL", $params);
        return $result;
    }